### PR TITLE
Remove the dependency on 'bazaar'

### DIFF
--- a/component.yml
+++ b/component.yml
@@ -15,8 +15,6 @@ description: "This is a flavour that makes EPrints into a research publications 
 requires:
   - component: "core"
     version: ">= 3.5.0"
-  - component: ingredient:bazaar
-    version: ">= 2.0"
   - component: ingredient:easy_pages
     version: ">= 2.0"
   - component: ingredient:richtext

--- a/package.yml.tmpl
+++ b/package.yml.tmpl
@@ -3,8 +3,6 @@ name: "Research Publications"
 includes:
   - path: flavours/pub_lib
     version: ">= 3.5.0"
-  - path: ingredients/bazaar
-    version: ">= 2.0"
   - path: ingredients/easy_pages
     version: ">= 2.0"
   - path: ingredients/richtext


### PR DESCRIPTION
The bazaar ingredient is being removed for 3.5 (eprints/eprints3.5#90) so shouldn't be included as a dependency of pub_lib.

#### Sister PR to eprints/eprints3.5#215