### PR TITLE
Switch to use triggers rather than functions where available

### DIFF
--- a/cfg.d/eprint_fields_default.pl
+++ b/cfg.d/eprint_fields_default.pl
@@ -1,11 +1,8 @@
-
-$c->{set_eprint_defaults} = sub
-{
-	my( $data, $repository ) = @_;
-
-	$data->{type} = "article";
-};
-
+$c->add_dataset_trigger( 'eprint', EP_TRIGGER_DEFAULTS, sub {
+	my( %params ) = @_;
+	
+	$params{data}->{type} = 'article';
+});
 
 =head1 COPYRIGHT
 

--- a/cfg.d/eprint_validate.pl
+++ b/cfg.d/eprint_validate.pl
@@ -2,34 +2,30 @@
 
 ######################################################################
 #
-# validate_eprint( $eprint, $repository, $for_archive ) 
+# EP_TRIGGER_VALIDATE 'eprint' dataset trigger
 #
 ######################################################################
 #
-# $eprint 
+# $dataobj
 # - EPrint object
-# $repository 
+# $repository
 # - Repository object (the current repository)
 # $for_archive
-# - boolean (see comments at the start of the validation section)
-#
-# returns: @problems
-# - ARRAY of DOM objects (may be null)
+# - Is this being checked to go live (`1` means it is)
+# $problems
+# - ARRAYREF of DOM objects
 #
 ######################################################################
+#
 # Validate the whole eprint, this is the last part of a full 
 # validation so you don't need to duplicate tests in 
 # validate_eprint_meta, validate_field or validate_document.
 #
 ######################################################################
 
-$c->{validate_eprint} = sub
-{
-	my( $eprint, $repository, $for_archive ) = @_;
-
-	my $xml = $repository->xml();
-
-	my @problems = ();
+$c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_VALIDATE, sub {
+	my( %args ) = @_;
+	my( $repository, $eprint, $problems ) = @args{qw( repository dataobj problems )};
 
 	# If we don't have creators (eg. for a book) then we 
 	# must have editor(s). To disable that rule, remove the 
@@ -37,15 +33,12 @@ $c->{validate_eprint} = sub
 	if( !$eprint->is_set( "creators" ) && 
 		!$eprint->is_set( "editors" ) )
 	{
-		my $fieldname = $xml->create_element( "span", class=>"ep_problem_field:creators" );
-		push @problems, $repository->html_phrase( 
+		my $fieldname = $repository->make_element( "span", class=>"ep_problem_field:creators" );
+		push @$problems, $repository->html_phrase( 
 				"validate:need_creators_or_editors",
 				fieldname=>$fieldname );
 	}
-
-
-	return( @problems );
-};
+}, id => 'creator_or_editor');
 
 # If you want to import legacy data which is exempt from the normal
 # validation methods, then uncomment this function and make it return


### PR DESCRIPTION
There are some triggers that exist in `EPrints::Const` however have never actually been called however with eprints/eprints3.5#71 these will be called (and the functions they replace will be soft-deprecated).

Specifically this replaces `set_eprint_defaults`, `validate_eprint` and `eprint_warnings` with dataset trigger based alternatives.

#### This should be merged before its sibling PR eprints/eprints3.5#236