### PR TITLE
Issue #305: make help text for contributions field always shown

### DIFF
--- a/workflows/eprint/default/core.xml
+++ b/workflows/eprint/default/core.xml
@@ -36,7 +36,7 @@
   </epc:choose>
   <component id="c_contributors">><field ref="contributors" /></component>
 -->
-  <component id="c_contributions"><field ref="contributions" required="yes" input_lookup_url="{$config{rel_cgipath}}/users/lookup/contributor" /></component>
+  <component id="c_contributions" show_help="always"><field ref="contributions" required="yes" input_lookup_url="{$config{rel_cgipath}}/users/lookup/contributor" /></component>
 
   <epc:if test="type = 'exhibition'">
     <component id="c_num_pieces"><field ref="num_pieces"/></component>


### PR DESCRIPTION
I think regardless of what we decided to put in the help text or if we add javascript to improve the input, the help text for contributions should always be shown as it's a far more complex field than it used to be.