### PR TITLE
#17: undefined subject would fail to generate abstract

### DIFF
--- a/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -163,7 +163,7 @@ sub convert_dataobj
 			my $subject_obj = EPrints::DataObj::Subject->new( $plugin->{repository}, $subject );
 			my $subject_name = $subject;
 			if (defined $subject_obj){
-				# short term workaround, only do this if $subject_obj actually exists. this is subtly different to Subject::get_value_label
+				# short term workaround, only do this if $subject_obj actually exists. otherwise it's just raw name
 				my $subject_name = $subject_obj->render_description();
 			}
 

--- a/plugins/EPrints/Plugin/Export/HighwirePress.pm
+++ b/plugins/EPrints/Plugin/Export/HighwirePress.pm
@@ -161,7 +161,11 @@ sub convert_dataobj
 	if( $eprint->exists_and_set( 'subjects' ) ) {
 		for my $subject (@{$eprint->get_value( 'subjects' )}) {
 			my $subject_obj = EPrints::DataObj::Subject->new( $plugin->{repository}, $subject );
-			my $subject_name = $subject_obj->render_description();
+			my $subject_name = $subject;
+			if (defined $subject_obj){
+				# short term workaround, only do this if $subject_obj actually exists. this is subtly different to Subject::get_value_label
+				my $subject_name = $subject_obj->render_description();
+			}
 
 			$keywords .= '; ' if $keywords ne '';
 			$keywords .= $subject_name;
@@ -326,4 +330,3 @@ License along with EPrints 3.4.
 If not, see L<http://www.gnu.org/licenses/>.
 
 =for LICENSE END
-

--- a/plugins/EPrints/Plugin/Export/Prism.pm
+++ b/plugins/EPrints/Plugin/Export/Prism.pm
@@ -140,7 +140,11 @@ sub convert_dataobj
 	if( $eprint->exists_and_set( 'subjects' ) ) {
 		for my $subject (@{$eprint->get_value( 'subjects' )}) {
 			my $subject_obj = EPrints::DataObj::Subject->new( $plugin->{repository}, $subject );
-			my $subject_name = $subject_obj->render_description();
+			my $subject_name = $subject;
+			if (defined $subject_obj){
+				# short term workaround, only do this if $subject_obj actually exists. otherwise it's just raw name
+				my $subject_name = $subject_obj->render_description();
+			}
 
 			push @tags, [ 'prism.keyword', $subject_name ];
 		}
@@ -264,4 +268,3 @@ License along with EPrints 3.4.
 If not, see L<http://www.gnu.org/licenses/>.
 
 =for LICENSE END
-


### PR DESCRIPTION
Simple check to see if subject is defined. If it isn't then fall back to subject string.

Long term solution should really see first class Subject objects returned from the EPrint object somehow and this logic should be internal to EPrint, not in the exporter.