### PR TITLE
Add check for pdf mime type before rendering preview citation

### DIFF
--- a/cfg.d/eprint_render.pl
+++ b/cfg.d/eprint_render.pl
@@ -395,7 +395,7 @@ $c->{eprint_render} = sub
 	for my $doc ( @docs )
 	{
 		next if $doc->get_value("security") =~ m/validuser|staffonly/;
-		if ( $doc->get_value("format") =~ m/text/ ) {
+		if ( $doc->get_value("format") =~ m/text/ && $doc->get_value("mime_type") eq "application/pdf") {
 			$page->appendChild( $doc->render_citation( "summary_page_doc_pdf_preview", params => {} ) );
 			last;
 		}

--- a/cfg.d/eprint_render.pl
+++ b/cfg.d/eprint_render.pl
@@ -395,7 +395,7 @@ $c->{eprint_render} = sub
 	for my $doc ( @docs )
 	{
 		next if $doc->get_value("security") =~ m/validuser|staffonly/;
-		if ( $doc->get_value("format") =~ m/text/ && $doc->get_value("mime_type") eq "application/pdf") {
+		if ( $doc->get_value("mime_type") eq "application/pdf") {
 			$page->appendChild( $doc->render_citation( "summary_page_doc_pdf_preview", params => {} ) );
 			last;
 		}


### PR DESCRIPTION
Fixes eprints/eprints3.5#367 Adds a check for mime type before showing the pdf viewer, to ensure the document is a pdf